### PR TITLE
drop edit from component names

### DIFF
--- a/components/PersonalInfoSection.js
+++ b/components/PersonalInfoSection.js
@@ -12,7 +12,7 @@ import {
 import InfoIcon from '@mui/icons-material/Info';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
-export default function EditProfileSection() {
+export default function PesronalInfoSection() {
   const handleSubmit = (event) => {
     event.preventDefault();
     const data = new FormData(event.currentTarget);
@@ -32,7 +32,7 @@ export default function EditProfileSection() {
           >
             <Grid display='flex' alignItems='center'>
               <InfoIcon style={{ fontSize: '2.25em' }} sx={{ pr: 1 }} />
-              <Typography variant='h5'>Profile</Typography>
+              <Typography variant='h5'>Personal Info</Typography>
             </Grid>
           </AccordionSummary>
           <AccordionDetails>

--- a/components/ResumeSection.js
+++ b/components/ResumeSection.js
@@ -11,7 +11,7 @@ import {
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
-export default function EditResumeSection() {
+export default function ResumeSection() {
   const handleSubmit = (event) => {
     event.preventDefault();
     const data = new FormData(event.currentTarget);

--- a/pages/resume-new.js
+++ b/pages/resume-new.js
@@ -1,27 +1,30 @@
-import EditResumeSection from '@/components/EditResumeSection';
-import EditProfileSection from '@/components/EditProfileSection';;
-import React from "react";
+import ResumeSection from '@/components/ResumeSection';
+import PesronalInfoSection from '@/components/PersonalInfoSection';
+import React from 'react';
 import dynamic from 'next/dynamic';
 
-const PDFViewerComponent = dynamic(() => import('@react-pdf/renderer').then(module => module.PDFViewer), {
-  loading: () => <p>Loading PDF Viewer...</p>,
-  ssr: false // This ensures that the component is not loaded on the server side
-});
+const PDFViewerComponent = dynamic(
+  () => import('@react-pdf/renderer').then((module) => module.PDFViewer),
+  {
+    loading: () => <p>Loading PDF Viewer...</p>,
+    ssr: false, // This ensures that the component is not loaded on the server side
+  }
+);
 import MyDocument from '@/components/MyDocument';
 
 export default function ResumeNew() {
   return (
     <div style={{ display: 'flex' }}>
       <div style={{ flex: 1, padding: '10px' }}>
-        <EditResumeSection />
-        <EditProfileSection />
+        <ResumeSection />
+        <PesronalInfoSection />
       </div>
 
       <div style={{ width: '50%', padding: '10px' }}>
         <PDFViewerComponent
           style={{
-            width: "100%",
-            height: "1000px"
+            width: '100%',
+            height: '1000px',
           }}
         >
           <MyDocument />


### PR DESCRIPTION
- fix wrong name of component from profile to PersonalInfo
- dropped "edit" from component names of our sections.